### PR TITLE
Removes provider config

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -11,7 +11,3 @@ terraform {
     }
   }
 }
-
-provider "azurerm" {
-  features {}
-}


### PR DESCRIPTION
- The module at module.AzureMonitor is a legacy module which contains its own local provider configurations, and so calls to it may not use the count, for_each, or depends_on arguments